### PR TITLE
support for pressing enter in ace-jump-buffer menu to toggle to last buffer

### DIFF
--- a/ace-jump-buffer.el
+++ b/ace-jump-buffer.el
@@ -54,6 +54,10 @@
   :group 'ace-jump-buffer
   :type 'integer)
 
+(defcustom ajb-press-enter-for-last-buffer nil
+  "When true pressing enter will go to the last file for the current pane"
+  :group 'ace-jump-buffer)
+
 (defcustom ajb-sort-function 'bs-sort-buffers-by-recentf
   "The `bs-sort-function' function used when displaying `ace-jump-buffer'"
   :group 'ace-jump-buffer)
@@ -110,6 +114,9 @@
     (bs--set-window-height)
     (call-interactively 'ace-jump-line-mode)
     (define-key overriding-local-map (kbd "C-g") 'ace-jump-buffer-exit)
+    (when ajb-press-enter-for-last-buffer
+        (define-key overriding-local-map (kbd "<return>") '(lambda()(interactive)(ace-jump-buffer-exit) (switch-to-buffer (other-buffer (current-buffer) 1)))))
+
     (define-key overriding-local-map [t] 'ace-jump-buffer-exit)))
 
 ;;;###autoload


### PR DESCRIPTION
Howdy,

Thanks for making this. I really like this package for selecting from a giant list of buffers. So I did a `(define-key global-map (kbd "C-x b") 'ace-jump-buffer)`. Although I have a lot of muscle memory built up for quickly pressing enter to switch (toggle) to the last buffer I was on (from the default `C-x b` behavior). So I made the attached tweaks. I don't know if it's out side the bounds of the features you want to support, but I thought I'd bring it up just in case. 

**This probably isn't ready to go as-is** I am not sure if there's a better way to do this (although I know there's probably a better name for the `defcustom`). Thanks again.
