### PR TITLE
Fix: ajb-sort-function has no effect

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Show a menu of buffers in the current project (`projectile` required.).
 The max window height for the buffer menu. The default is 20.
 
 ###### `ajb-sort-function`
-The function for sorting buffers in the menu. The default is `(bs--sort-by-recentf)`.
+The function for sorting buffers in the menu. The default is `nil`.
 
 ###### `ajb-bs-configuration`
 The `bs` configuration to use when displaying the menu with `ace-jump-buffer`. The default is `"all"`. If you use [`perspective`](https://github.com/nex3/perspective-el), you may set this to `"persp"` to scope the buffer list to your current workspace/project. If you use [`projectile`](https://github.com/bbatsov/projectile), you may set this to `"projectile"` to scope the buffer list to your current project.


### PR DESCRIPTION
The current code used let-binding to override `bs-buffer-sort-function` and then
called `bs--show-with-configuration`. But this binding was immediately reset,
since `bs--show-with-configuration` internally calls `bs-set-configuration`
which sets `bs-buffer-sort-function` back to nil. So the buffer lists were
actually never sorted (at least not according to ajb-sort-function).

This commit fixes the issue by advising `bs-set-configuration`. In order to
maintain previous behavior for exiting users, the default value of
`ajb-sort-function` was changed to nil. `defcustom` declaration was also
improved by providing choice of available sort functions.

Also, the existing usage of (obsolete) `defadvice` was replaced by `advice-add`.